### PR TITLE
Fix subdirectory content not being watched, updated

### DIFF
--- a/lurker.lua
+++ b/lurker.lua
@@ -62,7 +62,7 @@ function lurker.listdir(path, recursive, skipdotfiles)
   for _, f in pairs(lume.map(dir(path), fullpath)) do
     if not skipdotfiles or not f:match("/%.[^/]*$") then
       if recursive and isdir(f) then
-        lume.merge(t, lurker.listdir(f, true, true))
+        t = lume.merge(t, lurker.listdir(f, true, true))
       else
         table.insert(t, lume.trim(f, "/"))
       end


### PR DESCRIPTION
Lume.merge returns a new table, rather than updating the `t` variable in place, and subdirectory content is not actually added.