### PR TITLE
Add a mechanism to stop a hotswap from occurring.

### DIFF
--- a/lurker.lua
+++ b/lurker.lua
@@ -210,7 +210,11 @@ function lurker.hotswapfile(f)
   if lurker.state == "error" then 
     lurker.exiterrorstate()
   end
-  lurker.preswap(f)
+  if lurker.preswap(f) then
+    lurker.print("Hotswap of '{1}' aborted by preswap'", {f})
+    lurker.resetfile(f)
+    return
+  end
   local modname = lurker.modname(f)
   local t, ok, err = lume.time(lume.hotswap, modname)
   if ok then


### PR DESCRIPTION
This comes in handy when certain files need to be swapped with some other mechanism (for example - files which must be loaded into a specific environment).

To stop a swap, return true from lurker.preswap. Does not break any existing usage of preswap.