### PR TITLE
Remove dependence on deprecated functions for Love versions supporting love.filesystem.getInfo

### DIFF
--- a/lurker.lua
+++ b/lurker.lua
@@ -15,9 +15,33 @@ local lurker = { _version = "1.0.1" }
 
 
 local dir = love.filesystem.enumerate or love.filesystem.getDirectoryItems
-local isdir = love.filesystem.isDirectory
 local time = love.timer.getTime or os.time
-local lastmodified = love.filesystem.getLastModified
+
+local isdir
+local lastmodified
+
+if love.filesystem.getInfo then
+  isdir = function(path)
+    return (love.filesystem.getInfo(path, 'directory') ~= nil)
+  end
+
+  lastmodified = function(path)
+    local info = love.filesystem.getInfo(path)
+
+    if info == nil then
+      return nil, 'File does not exist'
+    end
+
+    if info.modtime == nil then
+      return nil, 'Could not determine file modification date.'
+    end
+
+    return info.modtime
+  end
+else
+  isdir = love.filesystem.isDirectory
+  lastmodified = love.filesystem.getLastModified
+end
 
 local lovecallbacknames = {
   "update",


### PR DESCRIPTION
- Replicate behavior of love.filesystem.getLastModified using getInfo
- Check getInfo result isn't nil before using it
- Tested with Love2D 0.10.2 and 11.2 on Ubuntu 18.04