### PR TITLE
More thorough mouse handling in onerror

### DIFF
--- a/lurker.lua
+++ b/lurker.lua
@@ -101,9 +101,21 @@ function lurker.onerror(e, nostacktrace)
   lurker.print("An error occurred; switching to error state")
   lurker.state = "error"
 
-  -- Release mouse
-  local setgrab = love.mouse.setGrab or love.mouse.setGrabbed
-  setgrab(false)
+  if love.mouse then
+    -- Release mouse
+    love.mouse.setVisible(true)
+
+    local setgrab = love.mouse.setGrab or love.mouse.setGrabbed
+    setgrab(false)
+
+    if love.mouse.setRelativeMode then
+      love.mouse.setRelativeMode(false)
+    end
+
+    if love.mouse.setCursor then
+      love.mouse.setCursor()
+    end
+  end
 
   -- Set up callbacks
   for _, v in pairs(lovecallbacknames) do


### PR DESCRIPTION
This PR handles a few more cases related to the mouse cursor when switching to an error state. It does the following :

- Make sure that the cursor is visible
- Disable relative mode
- Set the cursor style to default